### PR TITLE
Fix stage order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
   - docker
 
 stages:
+  - test
   - name: build
     if: branch = master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 stages:
   - test
   - name: build
-    if: branch = master
+    if: branch = master AND type != pull_request
 
 jobs:
   include:


### PR DESCRIPTION
Fix the order in which Travis CI processes build stages. Docker images would have been built before testing.